### PR TITLE
Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` at the workflow level in `.github/workflows/ci.yml`
- Restricts the `GITHUB_TOKEN` to read-only access, following the principle of least privilege
- Explicit permissions document the workflow's actual needs and keep it safe if defaults ever change

## Test plan

- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)